### PR TITLE
fix: always request total needed memory, as snakemake seems to count as single process

### DIFF
--- a/snakemake_executor_plugin_lsf/__init__.py
+++ b/snakemake_executor_plugin_lsf/__init__.py
@@ -152,7 +152,7 @@ class Executor(RemoteExecutor):
                 "No job memory information ('mem_mb' or 'mem_mb_per_cpu') is given "
                 "- submitting without. This might or might not work on your cluster."
             )
-        call += f" -R rusage[mem={mem_}]"
+        call += f" -R rusage[mem={mem_}/job]"
 
         # MPI job
         if job.resources.get("mpi", False):

--- a/snakemake_executor_plugin_lsf/__init__.py
+++ b/snakemake_executor_plugin_lsf/__init__.py
@@ -538,14 +538,6 @@ class Executor(RemoteExecutor):
                     if key.strip() == "DEFAULT_QUEUE":
                         lsf_config["DEFAULT_QUEUE"] = value.split("#")[0].strip()
                         break
-        lsf_conf_file = f"{lsf_config['LSF_CONFDIR']}/lsf.conf"
-        with open(lsf_conf_file, "r") as file:
-            for line in file:
-                if "=" in line and not line.strip().startswith("#"):
-                    key, value = line.strip().split("=", 1)
-                    if key.strip() == "LSF_JOB_MEMLIMIT":
-                        lsf_config["LSF_JOB_MEMLIMIT"] = value.split("#")[0].strip()
-                        break
 
         return lsf_config
 

--- a/snakemake_executor_plugin_lsf/__init__.py
+++ b/snakemake_executor_plugin_lsf/__init__.py
@@ -143,18 +143,15 @@ class Executor(RemoteExecutor):
         conv_fcts = {"K": 1024, "M": 1, "G": 1 / 1024, "T": 1 / (1024**2)}
         mem_unit = self.lsf_config.get("LSF_UNIT_FOR_LIMITS", "MB")
         conv_fct = conv_fcts[mem_unit[0]]
-        mem_perjob = self.lsf_config.get("LSB_JOB_MEMLIMIT", "n").lower()
         if job.resources.get("mem_mb_per_cpu"):
-            mem_ = job.resources.mem_mb_per_cpu * conv_fct
+            mem_ = job.resources.mem_mb_per_cpu * conv_fct * cpus_per_task
         elif job.resources.get("mem_mb"):
-            mem_ = job.resources.mem_mb * conv_fct / cpus_per_task
+            mem_ = job.resources.mem_mb * conv_fct
         else:
             self.logger.warning(
                 "No job memory information ('mem_mb' or 'mem_mb_per_cpu') is given "
                 "- submitting without. This might or might not work on your cluster."
             )
-        if mem_perjob == "y":
-            mem_ *= cpus_per_task
         call += f" -R rusage[mem={mem_}]"
 
         # MPI job


### PR DESCRIPTION
We have a cluster with the following setting:
```
        LSB_JOB_MEMLIMIT = N
```

For this case, the [lsf docs on `LSB_JOB_MEMLIMIT`](https://www.ibm.com/docs/en/spectrum-lsf/10.1.0?topic=lsfconf-lsb-job-memlimit) specify:

> When LSB_JOB_MEMLIMIT is N or not defined, the LSF-enforced per-job limit is disabled, and the OS-enforced per-process limit is enabled.

So your interpretation previously was, that each requested cpu is its own process. However, I think that the whole job is always one single process, because it simply runs snakemake again in the main bsub job. So I think we always need to request the full amount of needed memory via `-R rusage[mem={mem_}]`, no matter what the `LSB_JOB_MEMLIMIT` setting.

As a bit of backup / reasoning, here's what I saw for a rule that has `threads: 8` specified, and `resources: mem_mb = lambda wc, threads: threads * 4000` when run with the executor-pluging-lsf without the change proposed here. TL;DR is, it will only reserve the memory for one thread / cpu, but the process requires the total memory. Here's the logging output (shortened and redacted a bit):

```
TERM_MEMLIMIT: job killed after reaching LSF memory usage limit.
Exited with exit code 1.

Resource usage summary:

    CPU time :                                   15.81 sec.
    Max Memory :                                 4000 MB
    Average Memory :                             1403.00 MB
    Total Requested Memory :                     4000.00 MB
    Delta Memory :                               0.00 MB
    Max Swap :                                   -
    Max Processes :                              10
    Max Threads :                                26
    Run time :                                   57 sec.
    Turnaround time :                            57 sec.

The output (if any) follows:

[...]
Building DAG of jobs...
Using shell: /usr/bin/bash
Provided remote nodes: 1
Provided resources: mem_mb=32000, mem_mib=30518, disk_mb=11452, disk_mib=10922
Select jobs to execute...
Execute 1 jobs...

[Tue Mar 12 23:20:42 2024]
rule bwa_mem:
[...]
    jobid: 0
    reason: Forced execution
[...]
    threads: 8
    resources: mem_mb=32000, mem_mib=30518, disk_mb=11452, disk_mib=10922, tmpdir=<TBD>, lsf_queue=long

[...]
Building DAG of jobs...
Using shell: /usr/bin/bash
Provided cores: 8
Rules claiming more threads will be scaled down.
Provided resources: mem_mb=32000, mem_mib=30518, disk_mb=11452, disk_mib=10922
Select jobs to execute...
Execute 1 jobs...

[Tue Mar 12 23:20:51 2024]
localrule bwa_mem:
[...]
    jobid: 0
    reason: Forced execution
[...]
    threads: 8
    resources: mem_mb=32000, mem_mib=30518, disk_mb=11452, disk_mib=10922, tmpdir=/local/<user>/cluster_tmp, lsf_queue=long

Activating conda environment: .snakemake/conda/5dbb9e4bb1f45b4c08879cdb19603237_
Activating conda environment: .snakemake/conda/5dbb9e4bb1f45b4c08879cdb19603237_
Traceback (most recent call last):
  File "/omics/odcf/analysis/OE0377_projects/ec_dna/analyses/colo_320_dm/.snakemake/scripts/tmpdkme9zmf.wrapper.py", line 68, in <module>
    shell(
  File "/omics/groups/OE0377/internal/laehnemann/mambaforge/envs/snakemake_8/lib/python3.12/site-packages/snakemake/shell.py", line 297, in __new__
    raise sp.CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command 'set -euo pipefail;  (<command>' returned non-zero exit status 1.
RuleException:
CalledProcessError in file https://raw.githubusercontent.com/snakemake-workflows/dna-seq-short-read-circle-map/v1.2.3/workflow/rules/mapping.smk, line 18:
Command '<command>' returned non-zero exit status 1.
  File "https://raw.githubusercontent.com/snakemake-workflows/dna-seq-short-read-circle-map/v1.2.3/workflow/rules/mapping.smk", line 18, in __rule_bwa_mem
[Tue Mar 12 23:21:17 2024]
Error in rule bwa_mem:
    jobid: 0
[...]

Shutting down, this might take some time.
Exiting because a job execution failed. Look above for error message
Storing output in storage.
WorkflowError:
At least one job did not complete successfully.

[Tue Mar 12 23:21:17 2024]
Error in rule bwa_mem:
    jobid: 0
[...]

Shutting down, this might take some time.
Exiting because a job execution failed. Look above for error message
Storing output in storage.
WorkflowError:
At least one job did not complete successfully.
```