### PR TITLE
fix: use -hl to enforce per job and per host memory limits

### DIFF
--- a/snakemake_executor_plugin_lsf/__init__.py
+++ b/snakemake_executor_plugin_lsf/__init__.py
@@ -152,7 +152,10 @@ class Executor(RemoteExecutor):
                 "No job memory information ('mem_mb' or 'mem_mb_per_cpu') is given "
                 "- submitting without. This might or might not work on your cluster."
             )
-        call += f" -R rusage[mem={mem_}/job]"
+        # -hl should enforce that memory is requested per job and per host (not per
+        # thread, per task or anything else). For the docs, see:
+        # * https://www.ibm.com/docs/en/spectrum-lsf/10.1.0?topic=options-hl
+        call += f" -hl -R rusage[mem={mem_}]"
 
         # MPI job
         if job.resources.get("mpi", False):


### PR DESCRIPTION
We might have to additionally add a check whether [`LSB_RESOURCE_ENFORCE`](https://www.ibm.com/docs/en/spectrum-lsf/10.1.0?topic=lsfconf-lsb-resource-enforce) contains the `"memory"` string, and if it doesn't, we might have to resort back to the `/job` syntax in the `rusage[]` statement.