### PR TITLE
fix: remove constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ to specify them for every rule. Snakemake already has reasonable
 defaults built in, which are automatically activated when using any non-local executor
 (hence also with lsf). Use mem_mb_per_cpu to give the standard LSF type memory per CPU
 
-## MPI jobs {#cluster-lsf-mpi}
+## MPI jobs
 
 Snakemake\'s LSF backend also supports MPI jobs, see
 `snakefiles-mpi`{.interpreted-text role="ref"} for details.
@@ -97,7 +97,6 @@ You can use the following specifications:
 |------------------------------------|------------------|----------------------------------------|
 | `-q`                               | `lsf_queue`      | the queue a rule/job is to use         |
 | `--W`                              | `walltime`       | the walltime per job in minutes        |
-| `--constraint`                     | `constraint`     | may hold features on some clusters     |
 | `-R "rusage[mem=<memory_amount>]"` | `mem`, `mem_mb`  | memory a cluster node must provide     |
 |                                    |                  | (`mem`: string with unit, `mem_mb`: i) |
 | `-R "rusage[mem=<memory_amount>]"` | `mem_mb_per_cpu` | memory per reserved CPU                |

--- a/docs/further.md
+++ b/docs/further.md
@@ -57,7 +57,7 @@ to specify them for every rule. Snakemake already has reasonable
 defaults built in, which are automatically activated when using any non-local executor
 (hence also with lsf). Use mem_mb_per_cpu to give the standard LSF type memory per CPU
 
-## MPI jobs {#cluster-lsf-mpi}
+## MPI jobs
 
 Snakemake\'s LSF backend also supports MPI jobs, see
 `snakefiles-mpi`{.interpreted-text role="ref"} for details.
@@ -92,7 +92,6 @@ You can use the following specifications:
 |------------------------------------|------------------|----------------------------------------|
 | `-q`                               | `lsf_queue`      | the queue a rule/job is to use         |
 | `--W`                              | `walltime`       | the walltime per job in minutes        |
-| `--constraint`                     | `constraint`     | may hold features on some clusters     |
 | `-R "rusage[mem=<memory_amount>]"` | `mem`, `mem_mb`  | memory a cluster node must provide     |
 |                                    |                  | (`mem`: string with unit, `mem_mb`: i) |
 | `-R "rusage[mem=<memory_amount>]"` | `mem_mb_per_cpu` | memory per reserved CPU                |

--- a/snakemake_executor_plugin_lsf/__init__.py
+++ b/snakemake_executor_plugin_lsf/__init__.py
@@ -137,9 +137,6 @@ class Executor(RemoteExecutor):
         cpus_per_task = max(1, cpus_per_task)
         call += f" -n {cpus_per_task}"
 
-        # if job.resources.get("constraint"):
-        #    call += f" -C {job.resources.constraint}"
-
         conv_fcts = {"K": 1024, "M": 1, "G": 1 / 1024, "T": 1 / (1024**2)}
         mem_unit = self.lsf_config.get("LSF_UNIT_FOR_LIMITS", "MB")
         conv_fct = conv_fcts[mem_unit[0]]


### PR DESCRIPTION
Constraints are vestigial from Slurm. This removes them from the executor and docs.