### PR TITLE
Feature: read LSF_CONFIG_FILE if th user lacks permission to badmin

### DIFF
--- a/snakemake_executor_plugin_lsf/__init__.py
+++ b/snakemake_executor_plugin_lsf/__init__.py
@@ -528,7 +528,7 @@ class Executor(RemoteExecutor):
         return ""
 
     @staticmethod
-    def get_lsf_config():
+    def get_lsf_config(path="/etc/lsf.conf"):
         try:
             lsf_config_raw = subprocess.run(
                 "badmin showconf mbd", shell=True, capture_output=True, text=True, check=True

--- a/snakemake_executor_plugin_lsf/__init__.py
+++ b/snakemake_executor_plugin_lsf/__init__.py
@@ -529,13 +529,21 @@ class Executor(RemoteExecutor):
 
     @staticmethod
     def get_lsf_config():
-        lsf_config_raw = subprocess.run(
-            "badmin showconf mbd", shell=True, capture_output=True, text=True
-        )
-
-        lsf_config_lines = lsf_config_raw.stdout.strip().split("\n")
-        lsf_config_tuples = [tuple(x.strip().split(" = ")) for x in lsf_config_lines]
-        lsf_config = {x[0]: x[1] for x in lsf_config_tuples[1:]}
+        try:
+            lsf_config_raw = subprocess.run(
+                "badmin showconf mbd", shell=True, capture_output=True, text=True, check=True
+            ).stdout
+        except subprocess.CalledProcessError:
+            print("Could not get LSF config from badmin showconf mbd")
+            config_file_path = os.environ.get('LSF_CONFIG_FILE', path)
+            try:
+                with open(config_file_path, 'r') as file:
+                    lsf_config_raw = file.read()
+            except FileNotFoundError:
+                raise FileNotFoundError(f"LSF config file not found at {config_file_path}")
+        lsf_config_lines = lsf_config_raw.strip().split("\n")
+        lsf_config_tuples = [tuple(x.strip().split("=")) for x in lsf_config_lines if len(tuple(x.strip().split("=")))==2]
+        lsf_config = {x[0]: x[1] for x in lsf_config_tuples}
         clusters = subprocess.run(
             "lsclusters", shell=True, capture_output=True, text=True
         )


### PR DESCRIPTION
Hi Brian!

Our lab has a bug fix / small feature we'd like to contribute to [snakemake-executor-plugin-lsf](https://github.com/BEFH/snakemake-executor-plugin-lsf). On our LSF cluster, users don't have access to `badmin` to raw LSF config. However, we can read a configuration file with the path in the env var LSF_CONFIG_FILE which appears to have the same results. We modified `get_lsf_config` to try `badmin` and if that fails, try reading the LSF_CONFIG_FILE. This also allows users to provide a new env var and a custom "config" if required.

Please let us know if you have any feedback. Thanks!