### PR TITLE
Remove 'SSUSP' from list of failed jobs

### DIFF
--- a/snakemake_executor_plugin_lsf/__init__.py
+++ b/snakemake_executor_plugin_lsf/__init__.py
@@ -227,7 +227,7 @@ class Executor(RemoteExecutor):
         #
         # async with self.status_rate_limiter:
         #    # query remote middleware here
-        fail_stati = ("SSUSP", "EXIT", "USUSP")
+        fail_stati = ("EXIT", "USUSP")
         # Cap sleeping time between querying the status of all active jobs:
         max_sleep_time = 180
 


### PR DESCRIPTION
SSUSP indicates a job has been temporarily suspended by the cluster due to scheduling conflicts and will resume automatically when more resources are available again, thus it should be handled similar to a 'RUN' or 'PEND' state.

Close #14 