### PR TITLE
fix: handle unresponsive bjobs without crashing workflow

### DIFF
--- a/snakemake_executor_plugin_lsf/__init__.py
+++ b/snakemake_executor_plugin_lsf/__init__.py
@@ -243,6 +243,9 @@ class Executor(RemoteExecutor):
         for i in range(status_attempts):
             async with self.status_rate_limiter:
                 (status_of_jobs, job_query_duration) = await self.job_stati_bjobs()
+                if status_of_jobs is None and job_query_duration is None:
+                    self.logger.debug(f"Could not check status of job {self.run_uuid}, see error above.")
+                    continue
                 job_query_durations.append(job_query_duration)
                 self.logger.debug(f"status_of_jobs after bjobs is: {status_of_jobs}")
                 # only take jobs that are still active
@@ -348,6 +351,8 @@ class Executor(RemoteExecutor):
 
         statuses_all = []
 
+        res = query_duration = None
+        
         try:
             running_cmd = f"bjobs -noheader -o 'jobid stat' -aJ '*{uuid}*'"
             time_before_query = time.time()
@@ -370,7 +375,8 @@ class Executor(RemoteExecutor):
             )
             pass
 
-        res = {x[0]: x[1] for x in statuses_all}
+        if len(statuses_all) > 0:
+            res = {x[0]: x[1] for x in statuses_all}
 
         return (res, query_duration)
 


### PR DESCRIPTION
This solution is adapted from the same issue in snakemake-executor-plugin-slurm:
https://github.com/snakemake/snakemake-executor-plugin-slurm/pull/5

To document the underlying error that we get in our setup, whenever bjobs is unresponsive, is this:

```
The running job status query failed with command: bjobs -noheader -o 'jobid stat' -aJ '*d5fdf780-46fb-477a-ac44-04be6b324031*'
Error message: Failed in an LSF library call: Failed in sending/receiving a message: Connection reset by peer

Traceback (most recent call last):

  File "/path/to/mambaforge/envs/snakemake_lsf_plugin/lib/python3.12/site-packages/snakemake_interface_executor_plugins/executors/remote.py", line 190, in _wait_thread
    asyncio.run(self._wait_for_jobs())

  File "/path/to/mambaforge/envs/snakemake_lsf_plugin/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^

  File "/path/to/mambaforge/envs/snakemake_lsf_plugin/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/path/to/mambaforge/envs/snakemake_lsf_plugin/lib/python3.12/asyncio/base_events.py", line 685, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^

  File "/path/to/mambaforge/envs/snakemake_lsf_plugin/lib/python3.12/site-packages/snakemake_interface_executor_plugins/executors/remote.py", line 180, in _wait_for_jobs
    still_active_jobs = [
                        ^

  File "/path/to/mambaforge/envs/snakemake_lsf_plugin/lib/python3.12/site-packages/snakemake_executor_plugin_lsf/__init__.py", line 244, in check_active_jobs
    (status_of_jobs, job_query_duration) = await self.job_stati_bjobs()
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/path/to/mambaforge/envs/snakemake_lsf_plugin/lib/python3.12/site-packages/snakemake_executor_plugin_lsf/__init__.py", line 374, in job_stati_bjobs
    return (res, query_duration)
                 ^^^^^^^^^^^^^^

UnboundLocalError: cannot access local variable 'query_duration' where it is not associated with a value
```

The solution is to return `None` values in the `job_stati-bjobs` function and try again for the number of retries, with the `status_rate_limiter` providing a wait time and the `bjobs` command hopefully becoming available in the meantime...