### PR TITLE
fix: throw warning and continue, if any required response from job status query is missing

### DIFF
--- a/snakemake_executor_plugin_lsf/__init__.py
+++ b/snakemake_executor_plugin_lsf/__init__.py
@@ -209,7 +209,8 @@ class Executor(RemoteExecutor):
                 status_of_jobs, job_query_duration = await self.job_stati_bjobs()
                 self.logger.debug(
                     f"Checking job statuses, attempt {i}: "
-                    f"status_of_jobs={status_of_jobs}, query_duration={job_query_duration}"
+                    f"status_of_jobs={status_of_jobs}, "
+                    f"query_duration={job_query_duration}"
                 )
                 if status_of_jobs is None or job_query_duration is None:
                     self.logger.debug(

--- a/snakemake_executor_plugin_lsf/__init__.py
+++ b/snakemake_executor_plugin_lsf/__init__.py
@@ -207,7 +207,10 @@ class Executor(RemoteExecutor):
         for i in range(status_attempts):
             async with self.status_rate_limiter:
                 status_of_jobs, job_query_duration = await self.job_stati_bjobs()
-                self.logger.debug(f"Checking job statuses, attempt {i}: status_of_jobs={status_of_jobs}, query_duration={job_query_duration}")
+                self.logger.debug(
+                    f"Checking job statuses, attempt {i}: "
+                    f"status_of_jobs={status_of_jobs}, query_duration={job_query_duration}"
+                )
                 if status_of_jobs is None or job_query_duration is None:
                     self.logger.debug(
                         f"Could not check status of job {self.run_uuid}. "

--- a/snakemake_executor_plugin_lsf/__init__.py
+++ b/snakemake_executor_plugin_lsf/__init__.py
@@ -207,7 +207,8 @@ class Executor(RemoteExecutor):
         for i in range(status_attempts):
             async with self.status_rate_limiter:
                 status_of_jobs, job_query_duration = await self.job_stati_bjobs()
-                if status_of_jobs is None and job_query_duration is None:
+                self.logger.debug(f"Checking job statuses, attempt {i}: status_of_jobs={status_of_jobs}, query_duration={job_query_duration}")
+                if status_of_jobs is None or job_query_duration is None:
                     self.logger.debug(
                         f"Could not check status of job {self.run_uuid}. "
                         "See error above."


### PR DESCRIPTION
This should fix issue #26 and also introduces the debugging output suggested in that issue, so that this should be easier to debug in the future.