### PR TITLE
Fix command syntax for lsclusters subprocess call

### DIFF
--- a/snakemake_executor_plugin_lsf/__init__.py
+++ b/snakemake_executor_plugin_lsf/__init__.py
@@ -134,6 +134,7 @@ class Executor(RemoteExecutor):
         call += f" -n {self.get_cpus(job)}"
         mem_ = self.get_mem(job)
         if mem_:
+            call += f" -M {self.get_mem_limit(job)}"
             call += f" -R rusage[mem={mem_}]"
         call += f" -R span[{self.get_span(job)}]"
 
@@ -465,6 +466,21 @@ class Executor(RemoteExecutor):
         if self.lsf_config["LSF_MEMFMT"] == "perjob":
             mem_ *= cpus_total
         return mem_
+
+    def get_mem_limit(self, job: JobExecutorInterface):
+        """
+        Gets the total memory hard limit (-M) for the job in LSF units.
+        Unlike get_mem() which returns per-slot values for rusage,
+        this returns the total job memory for per-process enforcement.
+        """
+        conv_fcts = {"K": 1024, "M": 1, "G": 1 / 1024, "T": 1 / (1024**2)}
+        mem_unit = self.lsf_config.get("LSF_UNIT_FOR_LIMITS", "MB")
+        conv_fct = conv_fcts[mem_unit[0]]
+        if job.resources.get("mem_mb_per_cpu"):
+            return job.resources.mem_mb_per_cpu * conv_fct * self.get_cpus(job)
+        elif job.resources.get("mem_mb"):
+            return job.resources.mem_mb * conv_fct
+        return None
 
     def get_span(self, job: JobExecutorInterface):
         """

--- a/snakemake_executor_plugin_lsf/__init__.py
+++ b/snakemake_executor_plugin_lsf/__init__.py
@@ -465,7 +465,7 @@ class Executor(RemoteExecutor):
             mem_ = None
         if self.lsf_config["LSF_MEMFMT"] == "perjob":
             mem_ *= cpus_total
-        return mem_
+        return int(mem_)
 
     def get_mem_limit(self, job: JobExecutorInterface):
         """
@@ -477,9 +477,9 @@ class Executor(RemoteExecutor):
         mem_unit = self.lsf_config.get("LSF_UNIT_FOR_LIMITS", "MB")
         conv_fct = conv_fcts[mem_unit[0]]
         if job.resources.get("mem_mb_per_cpu"):
-            return job.resources.mem_mb_per_cpu * conv_fct * self.get_cpus(job)
+            return int(job.resources.mem_mb_per_cpu * conv_fct * self.get_cpus(job))
         elif job.resources.get("mem_mb"):
-            return job.resources.mem_mb * conv_fct
+            return int(job.resources.mem_mb * conv_fct)
         return None
 
     def get_span(self, job: JobExecutorInterface):

--- a/snakemake_executor_plugin_lsf/__init__.py
+++ b/snakemake_executor_plugin_lsf/__init__.py
@@ -640,7 +640,7 @@ class Executor(RemoteExecutor):
         lsf_config_tuples = [tuple(x.strip().split(" = ")) for x in lsf_config_lines]
         lsf_config = {x[0]: x[1] for x in lsf_config_tuples[1:]}
         clusters = subprocess.run(
-            ["lsclusters", "-w"], shell=True, capture_output=True, text=True
+            "lsclusters -w", shell=True, capture_output=True, text=True
         )
         lsf_config["LSF_CLUSTER"] = clusters.stdout.split("\n")[1].split()[0]
         lsf_config["LSB_EVENTS"] = (


### PR DESCRIPTION
"-w" is not sent with shell=True. Force single string with command and options