### PR TITLE
fix: changes for upstream resource processing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "snakemake-executor-plugin-lsf"
-version = "0.3.2"
+version = "0.3.4"
 description = "A Snakemake executor plugin for submitting jobs to a LSF cluster."
 authors = [
     "Brian Fulton-Howard <brian.fulton-howard@mssm.edu>",

--- a/snakemake_executor_plugin_lsf/__init__.py
+++ b/snakemake_executor_plugin_lsf/__init__.py
@@ -12,18 +12,20 @@ import os
 import re
 import subprocess
 import time
-from typing import List, AsyncGenerator
-from collections import Counter
 import uuid
 import math
+import shlex
+import packaging
+from typing import List, AsyncGenerator
+from collections import Counter
+from humanfriendly import InvalidTimespan, parse_timespan
+
+import snakemake.resources
 from snakemake_interface_executor_plugins.executors.base import SubmittedJobInfo
 from snakemake_interface_executor_plugins.executors.remote import RemoteExecutor
 from snakemake_interface_executor_plugins.settings import CommonSettings
 from snakemake_interface_executor_plugins.jobs import JobExecutorInterface
 from snakemake_interface_common.exceptions import WorkflowError
-import snakemake.resources
-from humanfriendly import InvalidTimespan, parse_timespan
-import shlex
 
 # Required:
 # Specify common settings shared by various executors.
@@ -557,6 +559,7 @@ class Executor(RemoteExecutor):
         if smv >= minver:
             try:
                 from snakemake.resources import Resource
+
                 return Resource.parse_human_friendly("runtime", time_str)
             except WorkflowError:
                 pass

--- a/snakemake_executor_plugin_lsf/__init__.py
+++ b/snakemake_executor_plugin_lsf/__init__.py
@@ -22,7 +22,7 @@ from snakemake_interface_executor_plugins.settings import CommonSettings
 from snakemake_interface_executor_plugins.jobs import JobExecutorInterface
 from snakemake_interface_common.exceptions import WorkflowError
 import snakemake.resources
-from humanfriendly import InvalidTimespan
+from humanfriendly import InvalidTimespan, parse_timespan
 import shlex
 
 # Required:
@@ -551,9 +551,21 @@ class Executor(RemoteExecutor):
         except ValueError:
             pass
 
-        # Try to parse as Snakemake time
+        # Try to parse as snakemake 9.16.3+ time
+        smv = packaging.version.parse(snakemake.__version__)
+        minver = packaging.version.parse("9.16.3")
+        if smv >= minver:
+            try:
+                from snakemake.resources import Resource
+                return Resource.parse_human_friendly("runtime", time_str)
+            except WorkflowError:
+                pass
+            except ImportError:
+                pass
+
+        # Try to parse as humanfriendly time
         try:
-            return math.ceil(snakemake.resources.parse_timespan(time_str) / 60)
+            return math.ceil(parse_timespan(time_str) / 60)
         except InvalidTimespan:
             pass
 


### PR DESCRIPTION
Versions of Snakemake prior to 9.16.3 were broken and subsequent versions did not fully utilize builtin time parsing. This fix remedies those issues.